### PR TITLE
Handle tab-separated values better

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -100,7 +100,7 @@ define sysctl (
       $qvalue = shellquote("${value}")
       # lint:endignore
       exec { "enforce-sysctl-value-${qtitle}":
-        unless  => "test \"$(sysctl -n ${qtitle})\" = ${qvalue}",
+        unless  => "test \"$(sysctl -n ${qtitle} | tr -s '[ \t]' ' ')\" = ${qvalue}",
         command => "sysctl -w ${qtitle}=${qvalue}",
         path    => ['/usr/sbin', '/sbin', '/usr/bin', '/bin'],
       }

--- a/spec/defines/init_spec.rb
+++ b/spec/defines/init_spec.rb
@@ -59,7 +59,7 @@ describe 'sysctl', type: :define do
 
       it do
         is_expected.to contain_exec('enforce-sysctl-value-net.ipv4.ip_forward').only_with(
-          unless:  'test "$(sysctl -n net.ipv4.ip_forward)" = ""',
+          unless:  "test \"$(sysctl -n net.ipv4.ip_forward | tr -s '[ \t]' ' ')\" = \"\"",
           command: 'sysctl -w net.ipv4.ip_forward=""',
           path:    ['/usr/sbin', '/sbin', '/usr/bin', '/bin'],
         )
@@ -99,7 +99,7 @@ describe 'sysctl', type: :define do
 
         it do
           is_expected.to contain_exec('enforce-sysctl-value-net.ipv4.ip_forward').only_with(
-            unless:  'test "$(sysctl -n net.ipv4.ip_forward)" = 1',
+            unless:  "test \"$(sysctl -n net.ipv4.ip_forward | tr -s '[ \t]' ' ')\" = 1",
             command: 'sysctl -w net.ipv4.ip_forward=1',
             path:    ['/usr/sbin', '/sbin', '/usr/bin', '/bin'],
           )


### PR DESCRIPTION
Example:
```yaml
sysctl::base::values:
  kernel.sem:
    value: '500 256000 32 8192'
```
Currently it is not idempotent because `sysctl -n` returns `500\t256000\t32\t8192` (hard tabs) and not sspace separated as the input value. This pull request uses `tr` to remove any extra spaces and hard tabs and replaces them with one space in between every value.

Inspired by https://github.com/thias/puppet-sysctl/pull/76 but uses `tr` instead of `sed`because it looks nicer IMHO.